### PR TITLE
Add Lingala localization for time unit strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ var i10n = {
 
 Each property holds an array containing the singular and the plural-suffix.
 
+Here is an example of a Lingala localization:
+
+``` js
+var lingala = {
+  milliSeconds: ['milisɛkɔ́ndɛ', ''],
+  seconds: ['sɛkɔ́ndɛ', ''],
+  minutes: ['miníti', ''],
+  hours: ['ngonga', ''],
+  days: ['mɔ́kɔlɔ', ''],
+  weeks: ['mpɔ́sɔ', ''],
+  months: ['sánzá', ''],
+  years: ['mbúla', '']
+};
+```
+
 If you don't need to specify the `to`-parameter, you can pass in the localization as second parameter:
 
 ``` js

--- a/test.js
+++ b/test.js
@@ -56,6 +56,37 @@ console.log(localizedElapsedTime.years.text);
 
 console.log(localizedElapsedTime.optimal);
 
+var lingala = {
+  milliSeconds: ['milisɛkɔ́ndɛ', ''],
+  seconds: ['sɛkɔ́ndɛ', ''],
+	minutes: ['miníti', ''],
+	hours: ['ngonga', ''],
+	days: ['mɔ́kɔlɔ', ''],
+	weeks: ['mpɔ́sɔ', ''],
+	months: ['sánzá', ''],
+	years: ['mbúla', '']
+};
+
+var localizedElapsedTimeWithLingala = new Elapsed(then, now, lingala);
+
+console.log(localizedElapsedTimeWithLingala.milliSeconds.text);
+
+console.log(localizedElapsedTimeWithLingala.seconds.text);
+
+console.log(localizedElapsedTimeWithLingala.minutes.text);
+
+console.log(localizedElapsedTimeWithLingala.hours.text);
+
+console.log(localizedElapsedTimeWithLingala.days.text);
+
+console.log(localizedElapsedTimeWithLingala.weeks.text);
+
+console.log(localizedElapsedTimeWithLingala.months.text);
+
+console.log(localizedElapsedTimeWithLingala.years.text);
+
+console.log(localizedElapsedTimeWithLingala.optimal);
+
 var localizedElapsedTimeWithImplicitNow = new Elapsed(then, german);
 
 console.log(localizedElapsedTimeWithImplicitNow.milliSeconds.text);


### PR DESCRIPTION
Add Lingala (ln) language support for elapsed time strings. Includes translations for all 8 time units (milliseconds, seconds, minutes, hours, days, weeks, months, years) with examples in test.js and documentation in README.md.