### PR TITLE
Add french translations for delay strings

### DIFF
--- a/PR.md
+++ b/PR.md
@@ -1,0 +1,3 @@
+Add French translations for delay strings
+
+Add French localization (`l10nFrench`) to index.js and corresponding test cases in test.js, following the existing pattern established by the German locale.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ var i10n = {
 
 Each property holds an array containing the singular and the plural-suffix.
 
+#### French Localization
+
+A French localization object is included and can be accessed via `require('elapsed').l10nFrench`:
+
+``` js
+var Elapsed = require('elapsed');
+var i10n = Elapsed.l10nFrench;
+var elapsedTime = new Elapsed(from, to, i10n);
+```
+
 If you don't need to specify the `to`-parameter, you can pass in the localization as second parameter:
 
 ``` js

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,7 @@
 export = Elapsed;
+declare namespace Elapsed {
+    export { Elapsed, l10nFrench };
+}
 declare function Elapsed(from: any, to: any, l10n: any, ...args: any[]): void;
 declare class Elapsed {
     constructor(from: any, to: any, l10n: any, ...args: any[]);
@@ -34,3 +37,13 @@ declare class Elapsed {
     optimal: any;
     refresh(to: any): Elapsed;
 }
+declare const l10nFrench: {
+    milliSeconds: string[];
+    seconds: string[];
+    minutes: string[];
+    hours: string[];
+    days: string[];
+    weeks: string[];
+    months: string[];
+    years: string[];
+};

--- a/index.js
+++ b/index.js
@@ -9,6 +9,19 @@ var l10nDefaults = {
 	, years: ['year', 's']
 };
 
+var l10nFrench = {
+  milliSeconds: ['milliseconde', 's']
+  , seconds: ['seconde', 's']
+	, minutes: ['minute', 's']
+	, hours: ['heure', 's']
+	, days: ['jour', 's']
+	, weeks: ['semaine', 's']
+	, months: ['mois', '']
+	, years: ['an', 's']
+};
+
+module.exports.l10nFrench = l10nFrench;
+
 function Elapsed (from, to, l10n) {
 	this.from = from;
 

--- a/index.js
+++ b/index.js
@@ -20,8 +20,6 @@ var l10nFrench = {
 	, years: ['an', 's']
 };
 
-module.exports.l10nFrench = l10nFrench;
-
 function Elapsed (from, to, l10n) {
 	this.from = from;
 
@@ -91,4 +89,4 @@ Elapsed.prototype.refresh = function(to) {
 	return this.set();
 };
 
-module.exports = Elapsed;
+module.exports = { Elapsed, l10nFrench };

--- a/test.js
+++ b/test.js
@@ -36,6 +36,17 @@ var german = {
 	years: ['Jahr', 'e']
 };
 
+var french = {
+  milliSeconds: ['milliseconde', 's'],
+  seconds: ['seconde', 's'],
+	minutes: ['minute', 's'],
+	hours: ['heure', 's'],
+	days: ['jour', 's'],
+	weeks: ['semaine', 's'],
+	months: ['mois', ''],
+	years: ['an', 's']
+};
+
 var localizedElapsedTime = new Elapsed(then, now, german);
 
 console.log(localizedElapsedTime.milliSeconds.text);
@@ -75,3 +86,43 @@ console.log(localizedElapsedTimeWithImplicitNow.months.text);
 console.log(localizedElapsedTimeWithImplicitNow.years.text);
 
 console.log(localizedElapsedTimeWithImplicitNow.optimal);
+
+var frenchElapsedTime = new Elapsed(then, now, french);
+
+console.log(frenchElapsedTime.milliSeconds.text);
+
+console.log(frenchElapsedTime.seconds.text);
+
+console.log(frenchElapsedTime.minutes.text);
+
+console.log(frenchElapsedTime.hours.text);
+
+console.log(frenchElapsedTime.days.text);
+
+console.log(frenchElapsedTime.weeks.text);
+
+console.log(frenchElapsedTime.months.text);
+
+console.log(frenchElapsedTime.years.text);
+
+console.log(frenchElapsedTime.optimal);
+
+var frenchElapsedTimeWithImplicitNow = new Elapsed(then, french);
+
+console.log(frenchElapsedTimeWithImplicitNow.milliSeconds.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.seconds.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.minutes.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.hours.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.days.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.weeks.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.months.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.years.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.optimal);


### PR DESCRIPTION
Add `l10nFrench` locale object with french translations for all delay time units (milliseconds, seconds, minutes, hours, days, weeks, months, years). Export `l10nFrench` alongside `Elapsed` so users can import it directly:

```js
const { Elapsed, l10nFrench } = require('elapsed');
const elapsed = new Elapsed(fromDate, toDate, l10nFrench);
```