### PR TITLE
Add French translations for delay strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,17 @@ var l10nDefaults = {
 	, years: ['year', 's']
 };
 
+var l10nFrench = {
+  milliSeconds: ['milliseconde', 's']
+  , seconds: ['seconde', 's']
+	, minutes: ['minute', 's']
+	, hours: ['heure', 's']
+	, days: ['jour', 's']
+	, weeks: ['semaine', 's']
+	, months: ['mois', '']
+	, years: ['an', 's']
+};
+
 function Elapsed (from, to, l10n) {
 	this.from = from;
 
@@ -79,3 +90,4 @@ Elapsed.prototype.refresh = function(to) {
 };
 
 module.exports = Elapsed;
+module.exports.l10nFrench = l10nFrench;

--- a/test.js
+++ b/test.js
@@ -25,6 +25,37 @@ console.log(elapsedTime.years.text);
 
 console.log(elapsedTime.optimal);
 
+var french = {
+  milliSeconds: ['milliseconde', 's'],
+  seconds: ['seconde', 's'],
+	minutes: ['minute', 's'],
+	hours: ['heure', 's'],
+	days: ['jour', 's'],
+	weeks: ['semaine', 's'],
+	months: ['mois', ''],
+	years: ['an', 's']
+};
+
+var frenchElapsedTime = new Elapsed(then, now, french);
+
+console.log(frenchElapsedTime.milliSeconds.text);
+
+console.log(frenchElapsedTime.seconds.text);
+
+console.log(frenchElapsedTime.minutes.text);
+
+console.log(frenchElapsedTime.hours.text);
+
+console.log(frenchElapsedTime.days.text);
+
+console.log(frenchElapsedTime.weeks.text);
+
+console.log(frenchElapsedTime.months.text);
+
+console.log(frenchElapsedTime.years.text);
+
+console.log(frenchElapsedTime.optimal);
+
 var german = {
   milliSeconds: ['millisekunde', 'n'],
   seconds: ['Sekunde', 'n'],


### PR DESCRIPTION
Adds `l10nFrench` localization object with French translations for all time unit strings (milliseconds, seconds, minutes, hours, days, weeks, months, years). The locale is exported alongside the main `Elapsed` module for use in French-language applications.