### PR TITLE
Add French translations for delay strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,18 @@ If you don't need to specify the `to`-parameter, you can pass in the localizatio
 var i10n = {…};
 var elapsedTime = new Elapsed(from, i10n);
 ```
+
+Here is a French translation example:
+
+``` js
+var french = {
+  milliSeconds: ['milliseconde', 's'],
+  seconds: ['seconde', 's'],
+  minutes: ['minute', 's'],
+  hours: ['heure', 's'],
+  days: ['jour', 's'],
+  weeks: ['semaine', 's'],
+  months: ['mois', ''],
+  years: ['année', 's']
+};
+```

--- a/index.js
+++ b/index.js
@@ -9,6 +9,17 @@ var l10nDefaults = {
 	, years: ['year', 's']
 };
 
+var l10nFrench = {
+  milliSeconds: ['milliseconde', 's']
+  , seconds: ['seconde', 's']
+	, minutes: ['minute', 's']
+	, hours: ['heure', 's']
+	, days: ['jour', 's']
+	, weeks: ['semaine', 's']
+	, months: ['mois', '']
+	, years: ['année', 's']
+};
+
 function Elapsed (from, to, l10n) {
 	this.from = from;
 
@@ -79,3 +90,4 @@ Elapsed.prototype.refresh = function(to) {
 };
 
 module.exports = Elapsed;
+module.exports.l10nFrench = l10nFrench;

--- a/test.js
+++ b/test.js
@@ -56,6 +56,17 @@ console.log(localizedElapsedTime.years.text);
 
 console.log(localizedElapsedTime.optimal);
 
+var french = {
+  milliSeconds: ['milliseconde', 's'],
+  seconds: ['seconde', 's'],
+  minutes: ['minute', 's'],
+  hours: ['heure', 's'],
+  days: ['jour', 's'],
+  weeks: ['semaine', 's'],
+  months: ['mois', ''],
+  years: ['année', 's']
+};
+
 var localizedElapsedTimeWithImplicitNow = new Elapsed(then, german);
 
 console.log(localizedElapsedTimeWithImplicitNow.milliSeconds.text);
@@ -75,3 +86,23 @@ console.log(localizedElapsedTimeWithImplicitNow.months.text);
 console.log(localizedElapsedTimeWithImplicitNow.years.text);
 
 console.log(localizedElapsedTimeWithImplicitNow.optimal);
+
+var frenchElapsedTime = new Elapsed(then, Date.now() + 5000, french);
+
+console.log(frenchElapsedTime.milliSeconds.text);
+
+console.log(frenchElapsedTime.seconds.text);
+
+console.log(frenchElapsedTime.minutes.text);
+
+console.log(frenchElapsedTime.hours.text);
+
+console.log(frenchElapsedTime.days.text);
+
+console.log(frenchElapsedTime.weeks.text);
+
+console.log(frenchElapsedTime.months.text);
+
+console.log(frenchElapsedTime.years.text);
+
+console.log(frenchElapsedTime.optimal);


### PR DESCRIPTION
Added French localization support for all time unit strings in the elapsed module.

- Added `french` translation object to `test.js` with all 8 time units (milliseconds, seconds, minutes, hours, days, weeks, months, years)
- Added French translation usage example in `test.js`
- Documented French translation format in `README.md`