### PR TITLE
Add French translations for delay strings

### DIFF
--- a/test.js
+++ b/test.js
@@ -36,6 +36,17 @@ var german = {
 	years: ['Jahr', 'e']
 };
 
+var french = {
+  milliSeconds: ['milliseconde', 's'],
+  seconds: ['seconde', 's'],
+	minutes: ['minute', 's'],
+	hours: ['heure', 's'],
+	days: ['jour', 's'],
+	weeks: ['semaine', 's'],
+	months: ['mois', ''],
+	years: ['an', 's']
+};
+
 var localizedElapsedTime = new Elapsed(then, now, german);
 
 console.log(localizedElapsedTime.milliSeconds.text);

--- a/test.js
+++ b/test.js
@@ -85,4 +85,53 @@ console.log(localizedElapsedTimeWithImplicitNow.months.text);
 
 console.log(localizedElapsedTimeWithImplicitNow.years.text);
 
-console.log(localizedElapsedTimeWithImplicitNow.optimal);
+var french = {
+  milliSeconds: ['milliseconde', 's'],
+  seconds: ['seconde', 's'],
+	minutes: ['minute', 's'],
+	hours: ['heure', 's'],
+	days: ['jour', 's'],
+	weeks: ['semaine', 's'],
+	months: ['mois', ''],
+	years: ['an', 's']
+};
+
+var localizedElapsedTimeWithFrench = new Elapsed(then, now, french);
+
+console.log(localizedElapsedTimeWithFrench.milliSeconds.text);
+
+console.log(localizedElapsedTimeWithFrench.seconds.text);
+
+console.log(localizedElapsedTimeWithFrench.minutes.text);
+
+console.log(localizedElapsedTimeWithFrench.hours.text);
+
+console.log(localizedElapsedTimeWithFrench.days.text);
+
+console.log(localizedElapsedTimeWithFrench.weeks.text);
+
+console.log(localizedElapsedTimeWithFrench.months.text);
+
+console.log(localizedElapsedTimeWithFrench.years.text);
+
+console.log(localizedElapsedTimeWithFrench.optimal);
+
+var localizedElapsedTimeWithFrenchImplicitNow = new Elapsed(then, french);
+
+console.log(localizedElapsedTimeWithFrenchImplicitNow.milliSeconds.text);
+
+console.log(localizedElapsedTimeWithFrenchImplicitNow.seconds.text);
+
+console.log(localizedElapsedTimeWithFrenchImplicitNow.minutes.text);
+
+console.log(localizedElapsedTimeWithFrenchImplicitNow.hours.text);
+
+console.log(localizedElapsedTimeWithFrenchImplicitNow.days.text);
+
+console.log(localizedElapsedTimeWithFrenchImplicitNow.weeks.text);
+
+console.log(localizedElapsedTimeWithFrenchImplicitNow.months.text);
+
+console.log(localizedElapsedTimeWithFrenchImplicitNow.years.text);
+
+console.log(localizedElapsedTimeWithFrenchImplicitNow.optimal);


### PR DESCRIPTION
Add French locale translations to the elapsed module test file, following the existing German localization pattern. The translations cover all time units: milliseconds, seconds, minutes, hours, days, weeks, months, and years.