### PR TITLE
Add French translations for elapsed time strings

### DIFF
--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -1,0 +1,10 @@
+module.exports = {
+  milliSeconds: ['milliseconde', 's']
+  , seconds: ['seconde', 's']
+  , minutes: ['minute', 's']
+  , hours: ['heure', 's']
+  , days: ['jour', 's']
+  , weeks: ['semaine', 's']
+  , months: ['mois', '']
+  , years: ['an', 's']
+};


### PR DESCRIPTION
Adds a new `l10n/fr.js` file containing French translations for all elapsed time units (milliseconds, seconds, minutes, hours, days, weeks, months, years). This allows users to localize the elapsed module output to French by passing the locale object to the constructor.