### PR TITLE
Add French translations for delay strings

### DIFF
--- a/fr.d.ts
+++ b/fr.d.ts
@@ -1,0 +1,12 @@
+declare const fr: {
+    milliSeconds: [string, string];
+    seconds: [string, string];
+    minutes: [string, string];
+    hours: [string, string];
+    days: [string, string];
+    weeks: [string, string];
+    months: [string, string];
+    years: [string, string];
+};
+
+export = fr;

--- a/fr.js
+++ b/fr.js
@@ -1,0 +1,10 @@
+module.exports = {
+  milliSeconds: ['milliseconde', 's']
+  , seconds: ['seconde', 's']
+	, minutes: ['minute', 's']
+	, hours: ['heure', 's']
+	, days: ['jour', 's']
+	, weeks: ['semaine', 's']
+	, months: ['mois', '']
+	, years: ['année', 's']
+};


### PR DESCRIPTION
Add French localization file (`fr.js`) with TypeScript declarations (`fr.d.ts`) for all elapsed time units: milliseconds, seconds, minutes, hours, days, weeks, months, and years.