### PR TITLE
Add French translations for delay strings

### DIFF
--- a/fr.d.ts
+++ b/fr.d.ts
@@ -1,0 +1,12 @@
+declare const fr: {
+    milliSeconds: [string, string];
+    seconds: [string, string];
+    minutes: [string, string];
+    hours: [string, string];
+    days: [string, string];
+    weeks: [string, string];
+    months: [string, string];
+    years: [string, string];
+};
+
+export = fr;

--- a/fr.js
+++ b/fr.js
@@ -1,0 +1,10 @@
+module.exports = {
+  milliSeconds: ['milliseconde', 's']
+  , seconds: ['seconde', 's']
+	, minutes: ['minute', 's']
+	, hours: ['heure', 's']
+	, days: ['jour', 's']
+	, weeks: ['semaine', 's']
+	, months: ['mois', '']
+	, years: ['année', 's']
+};

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,3 +34,15 @@ declare class Elapsed {
     optimal: any;
     refresh(to: any): Elapsed;
 }
+declare namespace Elapsed {
+    export const l10nFrench: {
+        milliSeconds: [string, string];
+        seconds: [string, string];
+        minutes: [string, string];
+        hours: [string, string];
+        days: [string, string];
+        weeks: [string, string];
+        months: [string, string];
+        years: [string, string];
+    };
+}

--- a/index.js
+++ b/index.js
@@ -9,6 +9,17 @@ var l10nDefaults = {
 	, years: ['year', 's']
 };
 
+var l10nFrench = {
+  milliSeconds: ['milliseconde', 's']
+  , seconds: ['seconde', 's']
+	, minutes: ['minute', 's']
+	, hours: ['heure', 's']
+	, days: ['jour', 's']
+	, weeks: ['semaine', 's']
+	, months: ['mois', '']
+	, years: ['an', 's']
+};
+
 function Elapsed (from, to, l10n) {
 	this.from = from;
 
@@ -79,3 +90,4 @@ Elapsed.prototype.refresh = function(to) {
 };
 
 module.exports = Elapsed;
+module.exports.l10nFrench = l10nFrench;

--- a/test.js
+++ b/test.js
@@ -75,3 +75,54 @@ console.log(localizedElapsedTimeWithImplicitNow.months.text);
 console.log(localizedElapsedTimeWithImplicitNow.years.text);
 
 console.log(localizedElapsedTimeWithImplicitNow.optimal);
+
+var french = {
+  milliSeconds: ['milliseconde', 's'],
+  seconds: ['seconde', 's'],
+	minutes: ['minute', 's'],
+	hours: ['heure', 's'],
+	days: ['jour', 's'],
+	weeks: ['semaine', 's'],
+	months: ['mois', ''],
+	years: ['an', 's']
+};
+
+var frenchElapsedTime = new Elapsed(then, now, french);
+
+console.log(frenchElapsedTime.milliSeconds.text);
+
+console.log(frenchElapsedTime.seconds.text);
+
+console.log(frenchElapsedTime.minutes.text);
+
+console.log(frenchElapsedTime.hours.text);
+
+console.log(frenchElapsedTime.days.text);
+
+console.log(frenchElapsedTime.weeks.text);
+
+console.log(frenchElapsedTime.months.text);
+
+console.log(frenchElapsedTime.years.text);
+
+console.log(frenchElapsedTime.optimal);
+
+var frenchElapsedTimeWithImplicitNow = new Elapsed(then, french);
+
+console.log(frenchElapsedTimeWithImplicitNow.milliSeconds.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.seconds.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.minutes.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.hours.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.days.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.weeks.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.months.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.years.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.optimal);


### PR DESCRIPTION
Add `l10nFrench` localization object with French translations for all delay time units (milliseconds, seconds, minutes, hours, days, weeks, months, years). Export it from the module and add corresponding test cases in test.js.