### PR TITLE
Add French translations for time unit strings

### DIFF
--- a/test.js
+++ b/test.js
@@ -75,3 +75,54 @@ console.log(localizedElapsedTimeWithImplicitNow.months.text);
 console.log(localizedElapsedTimeWithImplicitNow.years.text);
 
 console.log(localizedElapsedTimeWithImplicitNow.optimal);
+
+var french = {
+  milliSeconds: ['milliseconde', 's'],
+  seconds: ['seconde', 's'],
+	minutes: ['minute', 's'],
+	hours: ['heure', 's'],
+	days: ['jour', 's'],
+	weeks: ['semaine', 's'],
+	months: ['mois', ''],
+	years: ['année', 's']
+};
+
+var frenchLocalizedElapsedTime = new Elapsed(then, now, french);
+
+console.log(frenchLocalizedElapsedTime.milliSeconds.text);
+
+console.log(frenchLocalizedElapsedTime.seconds.text);
+
+console.log(frenchLocalizedElapsedTime.minutes.text);
+
+console.log(frenchLocalizedElapsedTime.hours.text);
+
+console.log(frenchLocalizedElapsedTime.days.text);
+
+console.log(frenchLocalizedElapsedTime.weeks.text);
+
+console.log(frenchLocalizedElapsedTime.months.text);
+
+console.log(frenchLocalizedElapsedTime.years.text);
+
+console.log(frenchLocalizedElapsedTime.optimal);
+
+var frenchLocalizedElapsedTimeWithImplicitNow = new Elapsed(then, french);
+
+console.log(frenchLocalizedElapsedTimeWithImplicitNow.milliSeconds.text);
+
+console.log(frenchLocalizedElapsedTimeWithImplicitNow.seconds.text);
+
+console.log(frenchLocalizedElapsedTimeWithImplicitNow.minutes.text);
+
+console.log(frenchLocalizedElapsedTimeWithImplicitNow.hours.text);
+
+console.log(frenchLocalizedElapsedTimeWithImplicitNow.days.text);
+
+console.log(frenchLocalizedElapsedTimeWithImplicitNow.weeks.text);
+
+console.log(frenchLocalizedElapsedTimeWithImplicitNow.months.text);
+
+console.log(frenchLocalizedElapsedTimeWithImplicitNow.years.text);
+
+console.log(frenchLocalizedElapsedTimeWithImplicitNow.optimal);


### PR DESCRIPTION
Add French localization support for all time unit strings (milliseconds, seconds, minutes, hours, days, weeks, months, years) following the existing translation pattern used for German.