### PR TITLE
Add French translations for delay strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ var i10n = {
 };
 ```
 
+French translations are also available:
+
+``` js
+var Elapsed = require('elapsed');
+var i10n = Elapsed.l10nFrench;
+var elapsedTime = new Elapsed(from, to, i10n);
+
+console.log(elapsedTime.hours.text);  // "552 heures"
+console.log(elapsedTime.optimal);     // "3 semaines"
+```
+
 Each property holds an array containing the singular and the plural-suffix.
 
 If you don't need to specify the `to`-parameter, you can pass in the localization as second parameter:

--- a/index.js
+++ b/index.js
@@ -9,6 +9,17 @@ var l10nDefaults = {
 	, years: ['year', 's']
 };
 
+var l10nFrench = {
+  milliSeconds: ['milliseconde', 's']
+  , seconds: ['seconde', 's']
+	, minutes: ['minute', 's']
+	, hours: ['heure', 's']
+	, days: ['jour', 's']
+	, weeks: ['semaine', 's']
+	, months: ['mois', '']
+	, years: ['an', 's']
+};
+
 function Elapsed (from, to, l10n) {
 	this.from = from;
 

--- a/index.js
+++ b/index.js
@@ -78,4 +78,16 @@ Elapsed.prototype.refresh = function(to) {
 	return this.set();
 };
 
+var l10nFrench = {
+  milliSeconds: ['milliseconde', 's']
+  , seconds: ['seconde', 's']
+	, minutes: ['minute', 's']
+	, hours: ['heure', 's']
+	, days: ['jour', 's']
+	, weeks: ['semaine', 's']
+	, months: ['mois', '']
+	, years: ['an', 's']
+};
+
 module.exports = Elapsed;
+module.exports.l10nFrench = l10nFrench;


### PR DESCRIPTION
Adds `l10nFrench` localization object to the elapsed module, providing French translations for all time unit strings (milliseconds, seconds, minutes, hours, days, weeks, months, years). The French locale is exported as `Elapsed.l10nFrench` for easy consumption. Documentation updated in README.md with usage example.