### PR TITLE
Add french translations for delays strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,17 @@ var l10nDefaults = {
 	, years: ['year', 's']
 };
 
+var l10nFrench = {
+  milliSeconds: ['milliseconde', 's']
+  , seconds: ['seconde', 's']
+	, minutes: ['minute', 's']
+	, hours: ['heure', 's']
+	, days: ['jour', 's']
+	, weeks: ['semaine', 's']
+	, months: ['mois', '']
+	, years: ['an', 's']
+};
+
 function Elapsed (from, to, l10n) {
 	this.from = from;
 
@@ -79,3 +90,7 @@ Elapsed.prototype.refresh = function(to) {
 };
 
 module.exports = Elapsed;
+module.exports.l10n = {
+  en: l10nDefaults,
+  fr: l10nFrench
+};

--- a/test.js
+++ b/test.js
@@ -56,7 +56,18 @@ console.log(localizedElapsedTime.years.text);
 
 console.log(localizedElapsedTime.optimal);
 
-var localizedElapsedTimeWithImplicitNow = new Elapsed(then, german);
+var french = {
+  milliSeconds: ['milliseconde', 's'],
+  seconds: ['seconde', 's'],
+	minutes: ['minute', 's'],
+	hours: ['heure', 's'],
+	days: ['jour', 's'],
+	weeks: ['semaine', 's'],
+	months: ['mois', ''],
+	years: ['an', 's']
+};
+
+var localizedElapsedTimeWithImplicitNow = new Elapsed(then, french);
 
 console.log(localizedElapsedTimeWithImplicitNow.milliSeconds.text);
 


### PR DESCRIPTION
Add French localization support to the elapsed time module by introducing a `l10nFrench` object containing translated delay strings for all time units (milliseconds, seconds, minutes, hours, days, weeks, months, years). Expose both English and French locales via `module.exports.l10n` for easy access.