### PR TITLE
Add French translations for delay strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,17 @@ var l10nDefaults = {
 	, years: ['year', 's']
 };
 
+var l10nFrench = {
+  milliSeconds: ['milliseconde', 's']
+  , seconds: ['seconde', 's']
+	, minutes: ['minute', 's']
+	, hours: ['heure', 's']
+	, days: ['jour', 's']
+	, weeks: ['semaine', 's']
+	, months: ['mois', '']
+	, years: ['an', 's']
+};
+
 function Elapsed (from, to, l10n) {
 	this.from = from;
 
@@ -79,3 +90,4 @@ Elapsed.prototype.refresh = function(to) {
 };
 
 module.exports = Elapsed;
+module.exports.french = l10nFrench;

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 var Elapsed = require('./');
+var french = require('./').french;
 
 var now = new Date();
 var then = new Date(2012, 03, 15, 15, 22);
@@ -75,3 +76,43 @@ console.log(localizedElapsedTimeWithImplicitNow.months.text);
 console.log(localizedElapsedTimeWithImplicitNow.years.text);
 
 console.log(localizedElapsedTimeWithImplicitNow.optimal);
+
+var frenchLocalized = new Elapsed(then, now, french);
+
+console.log(frenchLocalized.milliSeconds.text);
+
+console.log(frenchLocalized.seconds.text);
+
+console.log(frenchLocalized.minutes.text);
+
+console.log(frenchLocalized.hours.text);
+
+console.log(frenchLocalized.days.text);
+
+console.log(frenchLocalized.weeks.text);
+
+console.log(frenchLocalized.months.text);
+
+console.log(frenchLocalized.years.text);
+
+console.log(frenchLocalized.optimal);
+
+var frenchLocalizedWithImplicitNow = new Elapsed(then, french);
+
+console.log(frenchLocalizedWithImplicitNow.milliSeconds.text);
+
+console.log(frenchLocalizedWithImplicitNow.seconds.text);
+
+console.log(frenchLocalizedWithImplicitNow.minutes.text);
+
+console.log(frenchLocalizedWithImplicitNow.hours.text);
+
+console.log(frenchLocalizedWithImplicitNow.days.text);
+
+console.log(frenchLocalizedWithImplicitNow.weeks.text);
+
+console.log(frenchLocalizedWithImplicitNow.months.text);
+
+console.log(frenchLocalizedWithImplicitNow.years.text);
+
+console.log(frenchLocalizedWithImplicitNow.optimal);


### PR DESCRIPTION
Adds French locale support for the elapsed time module. The French translations are exported as `Elapsed.french` and can be passed as the l10n parameter to get French-language elapsed time output (e.g., "14 ans", "736 semaines", "5157 jours").