### PR TITLE
Add French translations for delay strings

### DIFF
--- a/test.js
+++ b/test.js
@@ -36,6 +36,17 @@ var german = {
 	years: ['Jahr', 'e']
 };
 
+var french = {
+  milliSeconds: ['milliseconde', 's'],
+  seconds: ['seconde', 's'],
+	minutes: ['minute', 's'],
+	hours: ['heure', 's'],
+	days: ['jour', 's'],
+	weeks: ['semaine', 's'],
+	months: ['mois', ''],
+	years: ['an', 's']
+};
+
 var localizedElapsedTime = new Elapsed(then, now, german);
 
 console.log(localizedElapsedTime.milliSeconds.text);
@@ -75,3 +86,43 @@ console.log(localizedElapsedTimeWithImplicitNow.months.text);
 console.log(localizedElapsedTimeWithImplicitNow.years.text);
 
 console.log(localizedElapsedTimeWithImplicitNow.optimal);
+
+var frenchElapsedTime = new Elapsed(then, now, french);
+
+console.log(frenchElapsedTime.milliSeconds.text);
+
+console.log(frenchElapsedTime.seconds.text);
+
+console.log(frenchElapsedTime.minutes.text);
+
+console.log(frenchElapsedTime.hours.text);
+
+console.log(frenchElapsedTime.days.text);
+
+console.log(frenchElapsedTime.weeks.text);
+
+console.log(frenchElapsedTime.months.text);
+
+console.log(frenchElapsedTime.years.text);
+
+console.log(frenchElapsedTime.optimal);
+
+var frenchElapsedTimeWithImplicitNow = new Elapsed(then, french);
+
+console.log(frenchElapsedTimeWithImplicitNow.milliSeconds.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.seconds.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.minutes.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.hours.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.days.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.weeks.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.months.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.years.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.optimal);


### PR DESCRIPTION
Adds French localization support for all time unit strings (milliseconds, seconds, minutes, hours, days, weeks, months, years) following the existing German translation pattern in test.js.