### PR TITLE
Add French translations for delay strings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,3 +34,15 @@ declare class Elapsed {
     optimal: any;
     refresh(to: any): Elapsed;
 }
+declare namespace Elapsed {
+    export const l10nFrench: {
+        milliSeconds: [string, string];
+        seconds: [string, string];
+        minutes: [string, string];
+        hours: [string, string];
+        days: [string, string];
+        weeks: [string, string];
+        months: [string, string];
+        years: [string, string];
+    };
+}

--- a/index.js
+++ b/index.js
@@ -9,6 +9,17 @@ var l10nDefaults = {
 	, years: ['year', 's']
 };
 
+var l10nFrench = {
+  milliSeconds: ['milliseconde', 's']
+  , seconds: ['seconde', 's']
+	, minutes: ['minute', 's']
+	, hours: ['heure', 's']
+	, days: ['jour', 's']
+	, weeks: ['semaine', 's']
+	, months: ['mois', '']
+	, years: ['an', 's']
+};
+
 function Elapsed (from, to, l10n) {
 	this.from = from;
 
@@ -79,3 +90,4 @@ Elapsed.prototype.refresh = function(to) {
 };
 
 module.exports = Elapsed;
+module.exports.l10nFrench = l10nFrench;


### PR DESCRIPTION
Add `l10nFrench` locale object with French translations for all time unit strings (milliseconds, seconds, minutes, hours, days, weeks, months, years). The locale is exported alongside the main Elapsed module for easy access.