### PR TITLE
Add French translations for delay strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,17 @@ var l10nDefaults = {
 	, years: ['year', 's']
 };
 
+var l10nDefaultsFR = {
+  milliSeconds: ['milliseconde', 's']
+  , seconds: ['seconde', 's']
+	, minutes: ['minute', 's']
+	, hours: ['heure', 's']
+	, days: ['jour', 's']
+	, weeks: ['semaine', 's']
+	, months: ['mois', '']
+	, years: ['année', 's']
+};
+
 function Elapsed (from, to, l10n) {
 	this.from = from;
 
@@ -79,3 +90,4 @@ Elapsed.prototype.refresh = function(to) {
 };
 
 module.exports = Elapsed;
+module.exports.l10nDefaultsFR = l10nDefaultsFR;

--- a/test.js
+++ b/test.js
@@ -56,6 +56,37 @@ console.log(localizedElapsedTime.years.text);
 
 console.log(localizedElapsedTime.optimal);
 
+var french = {
+  milliSeconds: ['milliseconde', 's'],
+  seconds: ['seconde', 's'],
+	minutes: ['minute', 's'],
+	hours: ['heure', 's'],
+	days: ['jour', 's'],
+	weeks: ['semaine', 's'],
+	months: ['mois', ''],
+	years: ['an', 's']
+};
+
+var localizedElapsedTimeWithFrench = new Elapsed(then, now, french);
+
+console.log(localizedElapsedTimeWithFrench.milliSeconds.text);
+
+console.log(localizedElapsedTimeWithFrench.seconds.text);
+
+console.log(localizedElapsedTimeWithFrench.minutes.text);
+
+console.log(localizedElapsedTimeWithFrench.hours.text);
+
+console.log(localizedElapsedTimeWithFrench.days.text);
+
+console.log(localizedElapsedTimeWithFrench.weeks.text);
+
+console.log(localizedElapsedTimeWithFrench.months.text);
+
+console.log(localizedElapsedTimeWithFrench.years.text);
+
+console.log(localizedElapsedTimeWithFrench.optimal);
+
 var localizedElapsedTimeWithImplicitNow = new Elapsed(then, german);
 
 console.log(localizedElapsedTimeWithImplicitNow.milliSeconds.text);


### PR DESCRIPTION
Add French localization support for all time unit strings (milliseconds, seconds, minutes, hours, days, weeks, months, years) following the existing German translation pattern.