### PR TITLE
Add French translations for delay strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,17 @@ var l10nDefaults = {
 	, years: ['year', 's']
 };
 
+var l10nFrench = {
+  milliSeconds: ['milliseconde', 's']
+  , seconds: ['seconde', 's']
+	, minutes: ['minute', 's']
+	, hours: ['heure', 's']
+	, days: ['jour', 's']
+	, weeks: ['semaine', 's']
+	, months: ['mois', '']
+	, years: ['an', 's']
+};
+
 function Elapsed (from, to, l10n) {
 	this.from = from;
 
@@ -79,3 +90,7 @@ Elapsed.prototype.refresh = function(to) {
 };
 
 module.exports = Elapsed;
+module.exports.l10n = {
+  defaults: l10nDefaults,
+  french: l10nFrench
+};

--- a/test.js
+++ b/test.js
@@ -36,6 +36,17 @@ var german = {
 	years: ['Jahr', 'e']
 };
 
+var french = {
+  milliSeconds: ['milliseconde', 's'],
+  seconds: ['seconde', 's'],
+	minutes: ['minute', 's'],
+	hours: ['heure', 's'],
+	days: ['jour', 's'],
+	weeks: ['semaine', 's'],
+	months: ['mois', ''],
+	years: ['an', 's']
+};
+
 var localizedElapsedTime = new Elapsed(then, now, german);
 
 console.log(localizedElapsedTime.milliSeconds.text);
@@ -55,6 +66,26 @@ console.log(localizedElapsedTime.months.text);
 console.log(localizedElapsedTime.years.text);
 
 console.log(localizedElapsedTime.optimal);
+
+var localizedElapsedTimeFrench = new Elapsed(then, now, french);
+
+console.log(localizedElapsedTimeFrench.milliSeconds.text);
+
+console.log(localizedElapsedTimeFrench.seconds.text);
+
+console.log(localizedElapsedTimeFrench.minutes.text);
+
+console.log(localizedElapsedTimeFrench.hours.text);
+
+console.log(localizedElapsedTimeFrench.days.text);
+
+console.log(localizedElapsedTimeFrench.weeks.text);
+
+console.log(localizedElapsedTimeFrench.months.text);
+
+console.log(localizedElapsedTimeFrench.years.text);
+
+console.log(localizedElapsedTimeFrench.optimal);
 
 var localizedElapsedTimeWithImplicitNow = new Elapsed(then, german);
 


### PR DESCRIPTION
Add French localization for all delay time unit strings (milliseconds, seconds, minutes, hours, days, weeks, months, years) to the test file, following the existing German translation pattern.