### PR TITLE
Add Lingala translation for delay strings

### DIFF
--- a/test.js
+++ b/test.js
@@ -56,6 +56,17 @@ console.log(localizedElapsedTime.years.text);
 
 console.log(localizedElapsedTime.optimal);
 
+var lingala = {
+  milliSeconds: ['milisɛkɔ́ndɛ', ''],
+  seconds: ['sɛkɔ́ndɛ', ''],
+	minutes: ['miniti', ''],
+	hours: ['ngonga', ''],
+	days: ['mokɔlɔ', ''],
+	weeks: ['poso', ''],
+	months: ['sanzi', ''],
+	years: ['mbula', '']
+};
+
 var localizedElapsedTimeWithImplicitNow = new Elapsed(then, german);
 
 console.log(localizedElapsedTimeWithImplicitNow.milliSeconds.text);
@@ -75,3 +86,23 @@ console.log(localizedElapsedTimeWithImplicitNow.months.text);
 console.log(localizedElapsedTimeWithImplicitNow.years.text);
 
 console.log(localizedElapsedTimeWithImplicitNow.optimal);
+
+var lingalaElapsedTime = new Elapsed(then, now, lingala);
+
+console.log(lingalaElapsedTime.milliSeconds.text);
+
+console.log(lingalaElapsedTime.seconds.text);
+
+console.log(lingalaElapsedTime.minutes.text);
+
+console.log(lingalaElapsedTime.hours.text);
+
+console.log(lingalaElapsedTime.days.text);
+
+console.log(lingalaElapsedTime.weeks.text);
+
+console.log(lingalaElapsedTime.months.text);
+
+console.log(lingalaElapsedTime.years.text);
+
+console.log(lingalaElapsedTime.optimal);


### PR DESCRIPTION
Adds Lingala (ln) locale translations for all delay/duration strings in the elapsed time module. The translation object includes singular forms for milliseconds, seconds, minutes, hours, days, weeks, months, and years, along with test coverage to verify the localized output.