### PR TITLE
Add French translations for elapsed time strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,22 @@ var i10n = {
 
 Each property holds an array containing the singular and the plural-suffix.
 
+Here is an example in French:
+
+``` js
+var french = {
+  milliSeconds: ['milliseconde', 's'],
+  seconds: ['seconde', 's'],
+  minutes: ['minute', 's'],
+  hours: ['heure', 's'],
+  days: ['jour', 's'],
+  weeks: ['semaine', 's'],
+  months: ['mois', ''],
+  years: ['an', 's']
+};
+var elapsedTime = new Elapsed(from, to, french);
+```
+
 If you don't need to specify the `to`-parameter, you can pass in the localization as second parameter:
 
 ``` js

--- a/test.js
+++ b/test.js
@@ -74,4 +74,53 @@ console.log(localizedElapsedTimeWithImplicitNow.months.text);
 
 console.log(localizedElapsedTimeWithImplicitNow.years.text);
 
-console.log(localizedElapsedTimeWithImplicitNow.optimal);
+var french = {
+  milliSeconds: ['milliseconde', 's'],
+  seconds: ['seconde', 's'],
+	minutes: ['minute', 's'],
+	hours: ['heure', 's'],
+	days: ['jour', 's'],
+	weeks: ['semaine', 's'],
+	months: ['mois', ''],
+	years: ['an', 's']
+};
+
+var frenchLocalizedElapsedTime = new Elapsed(then, now, french);
+
+console.log(frenchLocalizedElapsedTime.milliSeconds.text);
+
+console.log(frenchLocalizedElapsedTime.seconds.text);
+
+console.log(frenchLocalizedElapsedTime.minutes.text);
+
+console.log(frenchLocalizedElapsedTime.hours.text);
+
+console.log(frenchLocalizedElapsedTime.days.text);
+
+console.log(frenchLocalizedElapsedTime.weeks.text);
+
+console.log(frenchLocalizedElapsedTime.months.text);
+
+console.log(frenchLocalizedElapsedTime.years.text);
+
+console.log(frenchLocalizedElapsedTime.optimal);
+
+var frenchLocalizedElapsedTimeWithImplicitNow = new Elapsed(then, french);
+
+console.log(frenchLocalizedElapsedTimeWithImplicitNow.milliSeconds.text);
+
+console.log(frenchLocalizedElapsedTimeWithImplicitNow.seconds.text);
+
+console.log(frenchLocalizedElapsedTimeWithImplicitNow.minutes.text);
+
+console.log(frenchLocalizedElapsedTimeWithImplicitNow.hours.text);
+
+console.log(frenchLocalizedElapsedTimeWithImplicitNow.days.text);
+
+console.log(frenchLocalizedElapsedTimeWithImplicitNow.weeks.text);
+
+console.log(frenchLocalizedElapsedTimeWithImplicitNow.months.text);
+
+console.log(frenchLocalizedElapsedTimeWithImplicitNow.years.text);
+
+console.log(frenchLocalizedElapsedTimeWithImplicitNow.optimal);


### PR DESCRIPTION
Add French localization support with all time unit translations (milliseconde, seconde, minute, heure, jour, semaine, mois, an) following the existing German translation pattern. Includes test coverage and README documentation.