### PR TITLE
Add Lingala translation for delay strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,17 @@ var l10nDefaults = {
 	, years: ['year', 's']
 };
 
+var l10nLingala = {
+  milliSeconds: ['milisɛkɔ́ndɛ', '']
+  , seconds: ['sɛkɔ́ndɛ', '']
+	, minutes: ['miniti', '']
+	, hours: ['ngonga', '']
+	, days: ['mokɔlɔ', '']
+	, weeks: ['poso', '']
+	, months: ['sanza', '']
+	, years: ['mbula', '']
+};
+
 function Elapsed (from, to, l10n) {
 	this.from = from;
 
@@ -79,3 +90,4 @@ Elapsed.prototype.refresh = function(to) {
 };
 
 module.exports = Elapsed;
+module.exports.l10nLingala = l10nLingala;

--- a/test.js
+++ b/test.js
@@ -56,6 +56,17 @@ console.log(localizedElapsedTime.years.text);
 
 console.log(localizedElapsedTime.optimal);
 
+var lingala = {
+  milliSeconds: ['milisɛkɔ́ndɛ', ''],
+  seconds: ['sɛkɔ́ndɛ', ''],
+	minutes: ['miniti', ''],
+	hours: ['ngonga', ''],
+	days: ['mokolo', ''],
+	weeks: ['poso', ''],
+	months: ['sanza', ''],
+	years: ['mbula', '']
+};
+
 var localizedElapsedTimeWithImplicitNow = new Elapsed(then, german);
 
 console.log(localizedElapsedTimeWithImplicitNow.milliSeconds.text);
@@ -75,3 +86,23 @@ console.log(localizedElapsedTimeWithImplicitNow.months.text);
 console.log(localizedElapsedTimeWithImplicitNow.years.text);
 
 console.log(localizedElapsedTimeWithImplicitNow.optimal);
+
+var lingalaElapsedTime = new Elapsed(then, now, lingala);
+
+console.log(lingalaElapsedTime.milliSeconds.text);
+
+console.log(lingalaElapsedTime.seconds.text);
+
+console.log(lingalaElapsedTime.minutes.text);
+
+console.log(lingalaElapsedTime.hours.text);
+
+console.log(lingalaElapsedTime.days.text);
+
+console.log(lingalaElapsedTime.weeks.text);
+
+console.log(lingalaElapsedTime.months.text);
+
+console.log(lingalaElapsedTime.years.text);
+
+console.log(lingalaElapsedTime.optimal);


### PR DESCRIPTION
Add Lingala (ln) localization support for all time unit strings in the elapsed module. Includes translations for milliseconds, seconds, minutes, hours, days, weeks, months, and years with corresponding test cases.