### PR TITLE
Add French translations for elapsed time strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,17 @@ var l10nDefaults = {
 	, years: ['year', 's']
 };
 
+var l10nFrench = {
+  milliSeconds: ['milliseconde', 's']
+  , seconds: ['seconde', 's']
+	, minutes: ['minute', 's']
+	, hours: ['heure', 's']
+	, days: ['jour', 's']
+	, weeks: ['semaine', 's']
+	, months: ['mois', '']
+	, years: ['an', 's']
+};
+
 function Elapsed (from, to, l10n) {
 	this.from = from;
 
@@ -79,3 +90,4 @@ Elapsed.prototype.refresh = function(to) {
 };
 
 module.exports = Elapsed;
+module.exports.l10nFrench = l10nFrench;

--- a/test.js
+++ b/test.js
@@ -56,6 +56,57 @@ console.log(localizedElapsedTime.years.text);
 
 console.log(localizedElapsedTime.optimal);
 
+var french = {
+  milliSeconds: ['milliseconde', 's'],
+	seconds: ['seconde', 's'],
+	minutes: ['minute', 's'],
+	hours: ['heure', 's'],
+	days: ['jour', 's'],
+	weeks: ['semaine', 's'],
+	months: ['mois', ''],
+	years: ['an', 's']
+};
+
+var frenchElapsedTime = new Elapsed(then, now, french);
+
+console.log(frenchElapsedTime.milliSeconds.text);
+
+console.log(frenchElapsedTime.seconds.text);
+
+console.log(frenchElapsedTime.minutes.text);
+
+console.log(frenchElapsedTime.hours.text);
+
+console.log(frenchElapsedTime.days.text);
+
+console.log(frenchElapsedTime.weeks.text);
+
+console.log(frenchElapsedTime.months.text);
+
+console.log(frenchElapsedTime.years.text);
+
+console.log(frenchElapsedTime.optimal);
+
+var frenchElapsedTimeWithImplicitNow = new Elapsed(then, french);
+
+console.log(frenchElapsedTimeWithImplicitNow.milliSeconds.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.seconds.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.minutes.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.hours.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.days.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.weeks.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.months.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.years.text);
+
+console.log(frenchElapsedTimeWithImplicitNow.optimal);
+
 var localizedElapsedTimeWithImplicitNow = new Elapsed(then, german);
 
 console.log(localizedElapsedTimeWithImplicitNow.milliSeconds.text);


### PR DESCRIPTION
Add a `french` locale object to `test.js` with translations for all 8 time units (millisecond, second, minute, hour, day, week, month, year) following the existing German locale pattern. Also adds corresponding test cases demonstrating French localization with both explicit and implicit `now` dates.